### PR TITLE
Avoid O(n^2) case in horizontalConcat

### DIFF
--- a/elynx-tools/src/ELynx/Tools/Misc.hs
+++ b/elynx-tools/src/ELynx/Tools/Misc.hs
@@ -34,4 +34,4 @@ allValues = [minBound ..]
 -- checks are performed!
 horizontalConcat :: [[[a]]] -> [[a]]
 horizontalConcat [xs] = xs
-horizontalConcat xss = foldr (zipWith (++)) [] xss
+horizontalConcat xss = foldr1 (zipWith (++)) xss

--- a/elynx-tools/src/ELynx/Tools/Misc.hs
+++ b/elynx-tools/src/ELynx/Tools/Misc.hs
@@ -34,4 +34,4 @@ allValues = [minBound ..]
 -- checks are performed!
 horizontalConcat :: [[[a]]] -> [[a]]
 horizontalConcat [xs] = xs
-horizontalConcat xss = foldl' (zipWith (++)) (head xss) (tail xss)
+horizontalConcat xss = foldr (zipWith (++)) (head xss) (tail xss)

--- a/elynx-tools/src/ELynx/Tools/Misc.hs
+++ b/elynx-tools/src/ELynx/Tools/Misc.hs
@@ -34,4 +34,4 @@ allValues = [minBound ..]
 -- checks are performed!
 horizontalConcat :: [[[a]]] -> [[a]]
 horizontalConcat [xs] = xs
-horizontalConcat xss = foldr (zipWith (++)) (head xss) (tail xss)
+horizontalConcat xss = foldr (zipWith (++)) [] xss


### PR DESCRIPTION
Using foldl' here (or foldl) can result in a computation of (((a ++ b)++c)++...) which is quadratically slower than (a++(b++(c++...))). Using foldr rather than foldl' fixes this.
`length (head (horizontalConcat (replicate 10000 ["hi"])))` takes 0.0 seconds to run with this change rather than 2.6 seconds under the previous version.

I don't know anything about this project, but came across it while searching for a function that does exactly this using Hoogle. If you only use very small lists, feel free to ignore this suggestion.